### PR TITLE
Create valid URL for DELETE operations

### DIFF
--- a/index.js
+++ b/index.js
@@ -142,7 +142,7 @@ function deleteGrouping(grouping, callback) {
         return callback(null)
     }
 
-    const url = `${PUSHGATEWAY_URL}metrics/job/${job}/${labelName}/${labelValue}`
+    const url = PUSHGATEWAY_URL + encodeURIComponent(`metrics/job/${job}/${labelName}/${labelValue}`)
     logger.debug(`Delete URL: ${url}`)
     request.delete({
         url: url,


### PR DESCRIPTION
This commit makes sure that the path component of the DELETE query is properly escaped in case it contains non-alphanumeric characters.